### PR TITLE
feat: add volume 'node_modules'

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,5 +5,9 @@ services:
     image: node:12
     working_dir: /usr/src/app
     volumes:
-      - ./:/usr/src/app:cached
+      - ./:/usr/src/app
+      - /usr/src/app:node_modules
     command: [yarn, watch]
+
+volumes:
+  node_modules:


### PR DESCRIPTION
Docker for macでの動作が遅くなる問題に対策するため、node_modulesをdocker volume上に配置する用に変更。

これによってDockerを利用した場合はホスト側には空のnode_modulesディレクトリが生成され、コンテナ内と共有されなくなる。
node_modules内を見て支援を働かせるエディタ等を利用している場合にはホスト側でも参照用に `$ yarn` の実行が必要。