### PR TITLE
timeline bot による投稿の元投稿へのリンクを人間に優しく

### DIFF
--- a/src/models/time_post.ts
+++ b/src/models/time_post.ts
@@ -20,7 +20,8 @@ export default class TimePost {
       iconURL: msg.author.displayAvatarURL(),
     };
 
-    this.text = `${msg.content}\n> **[original post](<${msg.url}>)** <#${channel.id}>`;
+    const linkIconText = channel.topic || channel.name;
+    this.text = `[${linkIconText}](<${msg.url}>) ${msg.content}`;
   }
 
   webhookMessageOptions(): WebhookMessageOptions {

--- a/src/models/time_post.ts
+++ b/src/models/time_post.ts
@@ -20,7 +20,7 @@ export default class TimePost {
       iconURL: msg.author.displayAvatarURL(),
     };
 
-    const linkIconText = channel.topic || channel.name;
+    const linkIconText = channel.topic?.split('\n')[0] || `<#${channel.id}>`;
     this.text = `[${linkIconText}](<${msg.url}>) ${msg.content}`;
   }
 

--- a/src/models/time_post.ts
+++ b/src/models/time_post.ts
@@ -20,7 +20,7 @@ export default class TimePost {
       iconURL: msg.author.displayAvatarURL(),
     };
 
-    const linkIconText = channel.topic?.split('\n')[0] || `<#${channel.id}>`;
+    const linkIconText = channel.topic?.split('\n')[0] || channel.name;
     this.text = `[${linkIconText}](<${msg.url}>) ${msg.content}`;
   }
 


### PR DESCRIPTION
TextChannel の Topic の一行目に設定された文字列をリンクテキストとし、先頭に挿入する形に変更
チャンネル毎にTopic の一行目にリンクにしたい文字列（絵文字など）を入れて貰えば良い
