### PR TITLE
Feat/add query command

### DIFF
--- a/db/migrations/1613488971747-create_todo.ts
+++ b/db/migrations/1613488971747-create_todo.ts
@@ -1,0 +1,14 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class createTodo1613488971747 implements MigrationInterface {
+    name = 'createTodo1613488971747'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE "todo" ("id" SERIAL NOT NULL, "userId" character varying NOT NULL, "title" character varying NOT NULL, "description" character varying NOT NULL, CONSTRAINT "PK_d429b7114371f6a35c5cb4776a7" PRIMARY KEY ("id"))`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP TABLE "todo"`);
+    }
+
+}

--- a/src/commands/paiza/query.ts
+++ b/src/commands/paiza/query.ts
@@ -18,7 +18,7 @@ interface QueryCommandArgs {
   sql: string;
 }
 
-export default class HelloCommand extends Command {
+export default class QueryCommand extends Command {
   constructor(client: CommandoClient) {
     super(client, {
       name: 'query',

--- a/src/commands/paiza/query.ts
+++ b/src/commands/paiza/query.ts
@@ -33,10 +33,6 @@ export default class QueryCommand extends Command {
   }
   
   async run(msg: CommandoMessage, args: QueryCommandArgs): Promise<CommandoMessage> {
-    if (process.env.NODE_ENV === 'production') {
-      return msg.say('[!] this command is not available in the production environment.');
-    }
-    
     const manager = getManager();
     const response: {string: string}[] = await manager.query(args.sql);
     

--- a/src/commands/paiza/query.ts
+++ b/src/commands/paiza/query.ts
@@ -10,9 +10,6 @@ import {
 } from 'discord.js';
 
 import { getManager } from 'typeorm';
-import Constants from '../../constants';
-
-const API_KEY = Constants.paizaIO.API_KEY;
 
 interface QueryCommandArgs {
   sql: string;
@@ -70,7 +67,7 @@ function formatResponse(response: {string: string}[]): string {
   for (const [i, r] of Object.entries(responseByColumn)) {
     maxlen[i] = i.length;
     for (const v of r) {
-      maxlen[i] = Math.max(maxlen[i], (new String(v)).length);
+      maxlen[i] = Math.max(maxlen[i], String(v).length);
     }
   }
   
@@ -90,7 +87,7 @@ function formatResponse(response: {string: string}[]): string {
   for (const r of response) {
     const row = [];
     for (const [k, v] of Object.entries(r)) {
-      const sv = new String(v);
+      const sv = String(v);
       row.push(sv + ' '.repeat(maxlen[k] - sv.length));
     }
     output += row.join(' | ') + '\n';

--- a/src/commands/paiza/query.ts
+++ b/src/commands/paiza/query.ts
@@ -1,0 +1,100 @@
+import {
+  Command,
+  CommandInfo,
+  CommandoClient,
+  CommandoMessage,
+} from 'discord.js-commando';
+
+import {
+  MessageAttachment,
+} from 'discord.js';
+
+import { getManager } from 'typeorm';
+import Constants from '../../constants';
+
+const API_KEY = Constants.paizaIO.API_KEY;
+
+interface QueryCommandArgs {
+  query: string;
+}
+
+export default class HelloCommand extends Command {
+  constructor(client: CommandoClient) {
+    super(client, {
+      name: 'query',
+      group: 'paiza',
+      memberName: 'query',
+      description: 'DB 上で任意の SQL を実行し, 結果を返します.',
+      args: [
+        {
+          key: 'sql',
+          prompt: 'query',
+          type: 'string'
+        }
+      ]
+    } as CommandInfo);
+  }
+  
+  async run(msg: CommandoMessage, args: QueryCommandArgs): Promise<CommandoMessage> {
+    if (process.env.NODE_ENV === 'production') {
+      return msg.say('[!] this command is not available in the production environment.');
+    }
+    
+    const manager = getManager();
+    const response: {string: string}[] = await manager.query(args.query);
+    
+    const output = formatResponse(response);
+    
+    // Discord の文字数上限が 2000 文字なので 1994 文字以下ならテキストで返す
+    if (output.length <= 1994) {
+      return msg.say('```' + output + '```');
+    }
+    
+    const attach = new MessageAttachment(Buffer.from(output), 'output-' + msg.id + '.txt')
+    
+    return msg.say('length limit exceeded', attach);
+  }
+}
+
+function formatResponse(response: {string: string}[]): string {
+  const responseByColumn: {[column: string]: string[]} = {};
+  
+  for (const r of response) {
+    for (const [k, v] of Object.entries(r)) {
+      responseByColumn[k] = responseByColumn[k] || []
+      responseByColumn[k].push(v);
+    }
+  }
+  
+  const maxlen: {[column: string]: number} = {}
+  for (const [i, r] of Object.entries(responseByColumn)) {
+    maxlen[i] = i.length;
+    for (const v of r) {
+      maxlen[i] = Math.max(maxlen[i], (new String(v)).length);
+    }
+  }
+  
+  let output = '';
+  
+  const headers = [];
+  const separators = [];
+  
+  for (const [k, v] of Object.entries(maxlen)) {
+    headers.push(k + ' '.repeat(v - k.length));
+    separators.push('-'.repeat(v));
+  }
+  
+  output += headers.join(' | ') + '\n';
+  output += separators.join('-+-') + '\n';
+  
+  for (const r of response) {
+    const row = [];
+    for (const [k, v] of Object.entries(r)) {
+      const sv = new String(v);
+      row.push(sv + ' '.repeat(maxlen[k] - sv.length));
+    }
+    output += row.join(' | ') + '\n';
+  }
+  
+  return output;
+}

--- a/src/commands/paiza/query.ts
+++ b/src/commands/paiza/query.ts
@@ -15,7 +15,7 @@ import Constants from '../../constants';
 const API_KEY = Constants.paizaIO.API_KEY;
 
 interface QueryCommandArgs {
-  query: string;
+  sql: string;
 }
 
 export default class HelloCommand extends Command {
@@ -28,7 +28,7 @@ export default class HelloCommand extends Command {
       args: [
         {
           key: 'sql',
-          prompt: 'query',
+          prompt: 'sql',
           type: 'string'
         }
       ]
@@ -41,7 +41,7 @@ export default class HelloCommand extends Command {
     }
     
     const manager = getManager();
-    const response: {string: string}[] = await manager.query(args.query);
+    const response: {string: string}[] = await manager.query(args.sql);
     
     const output = formatResponse(response);
     

--- a/src/commands/paiza/todo_add.ts
+++ b/src/commands/paiza/todo_add.ts
@@ -1,0 +1,54 @@
+import {
+  Command,
+  CommandInfo,
+  CommandoClient,
+  CommandoMessage,
+} from 'discord.js-commando';
+import { Todo } from '../../entities/todo';
+
+interface TodoCommandArgs {
+  title: string;
+  description: string;
+}
+
+export default class TodoAddCommand extends Command {
+  constructor(client: CommandoClient) {
+    super(client, {
+      name: 'todo_add',
+      group: 'paiza',
+      memberName: 'todo_add',
+      description: '忘れないで あの日の思い出',
+      args: [
+        {
+          key: 'title',
+          prompt: 'todo title (only [add])',
+          type: 'string',
+        },
+        {
+          key: 'description',
+          prompt: 'todo description (only [add])',
+          type: 'string',
+          default: '',
+        },
+      ],
+    } as CommandInfo);
+  }
+
+  async run(
+    msg: CommandoMessage,
+    args: TodoCommandArgs,
+  ): Promise<CommandoMessage> {
+    console.log(args); // FIXME: TODO
+    const userId = msg.author.id; // FIXME: TODO
+    console.log(userId);
+
+    const todo = new Todo();
+    todo.userId = userId;
+    todo.title = args.title;
+    todo.description = args.description;
+
+    await todo.save();
+
+    return msg.say(`success. [${todo.title}]`);
+  }
+}

--- a/src/commands/paiza/todo_del.ts
+++ b/src/commands/paiza/todo_del.ts
@@ -1,0 +1,50 @@
+import {
+  Command,
+  CommandInfo,
+  CommandoClient,
+  CommandoMessage,
+} from 'discord.js-commando';
+import { Todo } from '../../entities/todo';
+
+interface TodoDelCommandArgs {
+  id: number;
+}
+
+export default class TodoDelCommand extends Command {
+  constructor(client: CommandoClient) {
+    super(client, {
+      name: 'todo_del',
+      group: 'paiza',
+      memberName: 'todo_del',
+      description: '今日の日は さようなら また会う日まで',
+      args: [
+        {
+          key: 'id',
+          prompt: 'todo id',
+          type: 'integer',
+        },
+      ],
+    } as CommandInfo);
+  }
+
+  async run(
+    msg: CommandoMessage,
+    args: TodoDelCommandArgs,
+  ): Promise<CommandoMessage> {
+    const todo = await Todo.findOne({ id: args.id });
+    const userId = msg.author.id;
+
+    if (!todo) {
+      return msg.say('[!] todo does not exists.');
+    }
+
+    if (todo.userId !== userId) {
+      return msg.say('[!] you are not owner of this todo.');
+    }
+
+    const todo_title = todo.title;
+    await todo.remove(); // DBの容量節約にレコードを物理削除
+
+    return msg.say(`success! remove [${todo_title}]`);
+  }
+}

--- a/src/commands/paiza/todo_list.ts
+++ b/src/commands/paiza/todo_list.ts
@@ -1,0 +1,59 @@
+import {
+  Command,
+  CommandInfo,
+  CommandoClient,
+  CommandoMessage,
+} from 'discord.js-commando';
+import { User } from 'discord.js';
+import { Todo } from '../../entities/todo';
+
+interface TodoListCommandArgs {
+  user: User;
+}
+
+export default class TodoListCommand extends Command {
+  constructor(client: CommandoClient) {
+    super(client, {
+      name: 'todo_list',
+      group: 'paiza',
+      memberName: 'todo_list',
+      description: 'そう 僕は気づいたんだ そう 僕は気づいた',
+      args: [
+        {
+          key: 'user',
+          prompt: 'whoes?',
+          type: 'user',
+          default: '',
+        },
+      ],
+    } as CommandInfo);
+  }
+
+  async run(
+    msg: CommandoMessage,
+    args: TodoListCommandArgs,
+  ): Promise<CommandoMessage> {
+    let user: User;
+
+    if (args.user) {
+      user = args.user;
+    } else {
+      user = msg.author;
+    }
+
+    const todos = await Todo.find({ userId: user.id });
+    let text: string;
+
+    if (todos.length !== 0) {
+      const todoList = [`${user.username}'s TODO LIST:`];
+      todos.forEach((todo) => {
+        todoList.push(`- ${todo.id}: ${todo.title}`);
+      });
+      text = todoList.join('\n');
+    } else {
+      text = ':tada: LGTM! :tada: WE ARE FREE!';
+    }
+
+    return msg.say(text);
+  }
+}

--- a/src/entities/todo.ts
+++ b/src/entities/todo.ts
@@ -1,0 +1,16 @@
+import { Entity, BaseEntity, PrimaryGeneratedColumn, Column } from 'typeorm';
+
+@Entity()
+export class Todo extends BaseEntity {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column()
+  userId!: string;
+
+  @Column()
+  title!: string;
+
+  @Column()
+  description?: string;
+}


### PR DESCRIPTION
#29 が merge されれば diff は落ち着くと思います。

変更は [src/commands/paiza/query.ts](https://github.com/paiza-learning/warriorsbot/blob/0f354f3f1f438baa6a03af7d4dac76bf79f31adf/src/commands/paiza/query.ts) のみです。

`/query <sql>` で与えた SQL を実行して、結果を 2000 文字以内に収まれば直接、収まらなければテキストファイルで返します。
production では動作しないようにしています（DBに何が蓄積されるかわからないので）。